### PR TITLE
Prevent from overriding TermIdentifier with new Id if duplicate entry is added.

### DIFF
--- a/src/collective/taxonomy/utility.py
+++ b/src/collective/taxonomy/utility.py
@@ -269,6 +269,7 @@ class Taxonomy(SimpleItem):
         for key, value in items:
             if key in seen:
                 logger.warning("Duplicate key entry: %r" % (key, ))
+                continue
 
             seen.add(key)
             update = key in tree


### PR DESCRIPTION
See also [https://github.com/collective/collective.taxonomy/issues/69](https://github.com/collective/collective.taxonomy/issues/69)